### PR TITLE
FIX for number cast exception on first opening of the preferences

### DIFF
--- a/src/main/java/io/github/thred/climatetray/ui/ClimateTrayPreferencesController.java
+++ b/src/main/java/io/github/thred/climatetray/ui/ClimateTrayPreferencesController.java
@@ -1,14 +1,14 @@
 /*
  * Copyright 2015 Manfred Hantschel
- * 
+ *
  * This file is part of Climate-Tray.
- * 
+ *
  * Climate-Tray is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
  * License as published by the Free Software Foundation, either version 3 of the License, or any later version.
- * 
+ *
  * Climate-Tray is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with Climate-Tray. If not, see
  * <http://www.gnu.org/licenses/>.
  */
@@ -79,7 +79,7 @@ public class ClimateTrayPreferencesController extends AbstractClimateTrayControl
     @Override
     public void refreshWith(ClimateTrayPreferences model)
     {
-        updatePeriodInMinutesSpinner.setValue(model.getUpdatePeriodInMinutes());
+        updatePeriodInMinutesSpinner.setValue((int) model.getUpdatePeriodInMinutes());
         temperatureUnitBox.setSelectedItem(model.getTemperatureUnit());
         versionCheckEnabledBox.setSelected(model.isVersionCheckEnabled());
 


### PR DESCRIPTION
model.getUpdatePeriodInMinutes() returns a Double
updatePeriodInMinutesSpinner is an Integer spinner

This causes a java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
on every initial opening of the preferences dialog for me.
